### PR TITLE
Add Bernstein to Development MCPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ This section highlights useful MCP servers you can add to your Copilot setup to 
 
 ### Development MCPs
 
+- [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Multi-agent orchestrator MCP server. Coordinates 37 CLI coding agents — including GitHub Copilot CLI — running in parallel git worktrees with deterministic Python scheduling, quality gates, and cost tracking.
 - [Playwright](https://github.com/microsoft/playwright-mcp) - Playwright MCP to automate browser interactions, test web pages and work with Playwright tests.
 - [Context7](https://github.com/upstash/context7) - Inject version-specific code documentation in your agent session to provide the correct API docs for code generation.
 


### PR DESCRIPTION
Adds [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) to **MCPs → Development MCPs** as a multi-agent orchestrator MCP server.

## Context

Re-submission after [#48](https://github.com/Code-and-Sorts/awesome-copilot-agents/pull/48) (which itself reopened [#42](https://github.com/Code-and-Sorts/awesome-copilot-agents/pull/42)). @colbytimm closed those because GitHub Copilot wasn't visible in Bernstein's README. That has since been fixed:

- Bernstein has shipped a Copilot CLI adapter (`src/bernstein/adapters/copilot.py`, registered in [`src/bernstein/adapters/registry.py`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/src/bernstein/adapters/registry.py)) — it was just missing from the README.
- README adapter table now lists [GitHub Copilot CLI](https://github.com/sipyourdrink-ltd/bernstein/blob/main/README.md#supported-agents) explicitly (commit [17c00428](https://github.com/sipyourdrink-ltd/bernstein/commit/17c00428)).
- Discussion: [#48 closing reply](https://github.com/Code-and-Sorts/awesome-copilot-agents/pull/48#issuecomment-4344475615) showing the registry entry and the README fix.

## What's different in this PR

The previous PRs added Bernstein to the top-of-README \`Contents\` table-of-contents list, which was the wrong place. This PR adds it in the right place — **MCPs → Development MCPs** — which is the section for MCP servers that extend Copilot's capabilities. Bernstein ships a first-class MCP server (\`bernstein mcp serve\`) that exposes its 37-adapter orchestrator as MCP tool calls, so it's a clean fit for that subsection.

Format follows the convention of the existing entries (single-line bullet, project link + dash + description). Description leads with what it is, mentions the GitHub Copilot CLI adapter explicitly, and avoids marketing language.

## What Bernstein is

Open-source governance layer for AI agents. Apache 2.0, Python 3.12+. Coordinates 37 cooperating CLI adapters (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor, Aider, Amp, OpenHands, OpenCode, Goose, Qwen, Ollama, and 26 more) running in parallel git worktrees. The scheduler is deterministic Python — zero LLM tokens spent on coordination. Quality gates (tests, lint, types) run before merge; cost tracking with budget enforcement; plan files with `depends_on` for multi-stage workflows; an MCP server mode lets any MCP-compatible client drive a run.

Happy to make any framing adjustments if the entry should sit in a different subsection or read differently.
